### PR TITLE
Minor bug in Krazy Talk TP handler

### DIFF
--- a/Assets/krazyTalkScript.cs
+++ b/Assets/krazyTalkScript.cs
@@ -473,6 +473,7 @@ public class krazyTalkScript : MonoBehaviour
                 yield break;
             }
 
+            yield return null;
             while (!Info.GetFormattedTime().EndsWith(time))
             {
                 yield return new WaitForSeconds(.5f);


### PR DESCRIPTION
TP handler incorrectly outputs an error message when the timer happens to be at the right time already when the command is processed, even though the command is in fact processed correctly.